### PR TITLE
Fix misaligned full screen effects (proper fix for 1440p issue)

### DIFF
--- a/d3d9ex/Context.h
+++ b/d3d9ex/Context.h
@@ -49,7 +49,7 @@ public:
 	void ApplyBehaviorFlagsFix(DWORD* flags);
 	HRESULT SetScissorRect(IDirect3DDevice9* pIDirect3DDevice9, CONST RECT* rect);
 	HRESULT CreateVertexBuffer(IDirect3DDevice9* pIDirect3DDevice9, UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9** ppVertexBuffer, HANDLE* pSharedHandle);
-	HRESULT SetViewport(IDirect3DDevice9* pIDirect3DDevice9, CONST D3DVIEWPORT9* pViewport);
+	HRESULT DrawPrimitiveUP(IDirect3DDevice9* pIDirect3DDevice9, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
 	bool BehaviorFlagsToString(DWORD BehaviorFlags, std::string* BehaviorFlagsString);
 
 	bool CheckWindow(HWND hWnd);
@@ -107,6 +107,20 @@ private:
 	uint32_t* ff13_2_internal_res_w;
 	uint32_t* ff13_2_internal_res_h;
 
+	float expectedDrawPrimitiveUpVertexData[5 * 4]
+	{ -1.00f - 1.0f / 1280.0f,       1.00f + 1.0f / 720.0f,    0.0f,    0.0f,    0.0f,
+	   1.00f - 1.0f / 1280.0f,       1.00f + 1.0f / 720.0f,    0.0f,    1.0f,    0.0f,
+	   1.00f - 1.0f / 1280.0f,      -1.00f + 1.0f / 720.0f,    0.0f,    1.0f,    1.0f,
+	  -1.00f - 1.0f / 1280.0f,      -1.00f + 1.0f / 720.0f,    0.0f,    0.0f,    1.0f
+	};
+
+	float fixedDrawPrimitiveUpVertexData[5 * 4]
+	{ -1.00f,       1.00f,    0.0f,    0.0f,    0.0f,
+	   1.00f,       1.00f,    0.0f,    1.0f,    0.0f,
+	   1.00f,      -1.00f,    0.0f,    1.0f,    1.0f,
+	  -1.00f,      -1.00f,    0.0f,    0.0f,    1.0f
+	};
+
 	const float FF13_2_30_FPS = 30.0F;
 	const float FF13_2_MAX_FRAME_CAP = 1000.0F;
 
@@ -138,6 +152,10 @@ private:
 	void FF13_2_AddHookIngameFrameRateLimitSetter();
 	void FF13_2_OneTimeFixes();
 	void FF13_2_EnableControllerVibration();
+
+	void AdjustVertexData(const uint32_t width, const uint32_t height);
+
+	bool MatchesExpectedVertexStream(const float* pVertexStreamZeroData);
 
 	bool OneTimeFixInit(std::unique_ptr<wchar_t[]>& className, HWND hWnd);
 	std::atomic_bool otf_init = false;

--- a/d3d9ex/IDirect3DDevice9.cpp
+++ b/d3d9ex/IDirect3DDevice9.cpp
@@ -261,7 +261,7 @@ HRESULT APIENTRY hkIDirect3DDevice9::MultiplyTransform(D3DTRANSFORMSTATETYPE Sta
 
 HRESULT APIENTRY hkIDirect3DDevice9::SetViewport(CONST D3DVIEWPORT9* pViewport) {
 	IDirect3DDevice9_PrintLog(__FUNCTION__);
-	return context.SetViewport(m_pWrapped, pViewport);
+	return m_pWrapped->SetViewport(pViewport);
 }
 
 HRESULT APIENTRY hkIDirect3DDevice9::GetViewport(D3DVIEWPORT9* pViewport) {
@@ -441,7 +441,7 @@ HRESULT APIENTRY hkIDirect3DDevice9::DrawIndexedPrimitive(D3DPRIMITIVETYPE Primi
 
 HRESULT APIENTRY hkIDirect3DDevice9::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
 	IDirect3DDevice9_PrintLog(__FUNCTION__);
-	return m_pWrapped->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+	return context.DrawPrimitiveUP(m_pWrapped, PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
 }
 
 HRESULT APIENTRY hkIDirect3DDevice9::DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount, CONST void* pIndexData, D3DFORMAT IndexDataFormat, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {


### PR DESCRIPTION
When mapping texels to pixels in Direct3D9 you need to change the vertex coordinates to account for the difference in the origin of the coordinates.

Check:
https://docs.microsoft.com/en-us/windows/win32/direct3d9/directly-mapping-texels-to-pixels

When the devs added support for other resolutions, they forgot to adjust the vertex to take in account the new pixel size.