### PR TITLE
[FF13] Allow usage of 4GB memory patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,19 @@ This considerably improves the frame rate when 2D elements are being disabled on
 ## Fix the enemy scan text on resolutions over 720p (FFXIII only)
 The game calls [SetScissorRect](https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setscissorrect) using a rectangle hardcoded with the 720p coordenates. This correct the coordenates and rectangle size in order to fix it.
 
-## Reporting issues
+# Usage with the 4GB Large Address Aware patch
+You may wish to patch the games to allow them to access more than 4GB of RAM. This seems to avoid crashes in FF13-2 (and may help FF13 under some configurations).
+## FF13:
+* Create a copy of the unpatched ```ffxiiiimg.exe``` to the folder ```FINAL FANTASY XIII\white_data\prog\win\bin```. Name it ```untouched.exe```.
+* Patch the original ```ffxiiiimg.exe``` (you can use https://ntcore.com/?page_id=371)
+## FF13-2: 
+* Patch ```ffxiii2img.exe``` (you can use https://ntcore.com/?page_id=371)
+
+# Reporting issues
 * Please specify what game are you talking about, which mods are you using (dxvk?) post system specs, and post FF13Fix.log
 * Add a save file and steps to reproduce the issue if possible
 
-## Other notes
+# Other notes
 * This is currently not compatible with GeDoSaTo. 
 * I strongly recommend forcing anisotropic filtering on your GPU driver to improve the quality of the textures.
 * Using "Maximum Performance" power management in the GPU driver can also help keeping the frame rate smooth. 

--- a/d3d9ex/Context.cpp
+++ b/d3d9ex/Context.cpp
@@ -50,8 +50,6 @@ MainContext::MainContext()
 	LogFile("FF13Fix.log");
 	context.PrintVersionInfo();
 
-	if (config.GetOptionsAutoFix()) EnableAutoFix();
-
 	PrintLog("Enabling hooks:");
 	const MH_STATUS initializeHooks = MH_Initialize();
 	PrintLog("initializeHooks = %d", initializeHooks);
@@ -80,6 +78,8 @@ MainContext::MainContext()
 	PrintLog("createHookSetWindowLongW = %d", createHookSetWindowLongW);
 	const MH_STATUS enableHookSetWindowLongW = MH_EnableHook(SetWindowLongW);
 	PrintLog("enableHookSetWindowLongW = %d", enableHookSetWindowLongW);
+
+	if (config.GetOptionsAutoFix()) EnableAutoFix();
 }
 
 MainContext::~MainContext()

--- a/d3d9ex/Context.h
+++ b/d3d9ex/Context.h
@@ -41,6 +41,8 @@ class MainContext
 	DECLARE_HOOK(HWND, WINAPI, CreateWindowExW, DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
 	DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam);
 
+	DECLARE_HOOK(HANDLE, WINAPI, CreateFileA, LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
+	DECLARE_HOOK(HANDLE, WINAPI, CreateFileW, LPCWSTR lpFileName,DWORD dwDesiredAccess,DWORD dwShareMode,LPSECURITY_ATTRIBUTES lpSecurityAttributes,DWORD dwCreationDisposition,DWORD dwFlagsAndAttributes,HANDLE hTemplateFile);
 public:
 	MainContext();
 	virtual ~MainContext();
@@ -95,6 +97,8 @@ private:
 	uint8_t* ff13_party_screen_scissor_scaling_factor_4 = NULL;
 	uint8_t* ff13_message_box_stack_push_address = NULL;
 	uint8_t* ff13_message_box_call_address = NULL;
+	uint8_t* ff13_exe_large_address_aware_flag_address = NULL;
+	uint8_t* ff13_exe_checksum_address = NULL;
 	uint32_t* ff13_internal_res_w;
 	uint32_t* ff13_internal_res_h;
 
@@ -151,6 +155,7 @@ private:
 	void FF13_SetFrameRateVariables();
 	void FF13_FixScissorRect();
 	void FF13_RemoveContinuousControllerScan();
+	void FF13_HandleLargeAddressAwarePatch();
 
 	void FF13_2_CreateSetFrameRateCodeBlock();
 	void FF13_2_InitializeGameAddresses();


### PR DESCRIPTION
The idea of patching CreateFileA came from reading the README from "4GB Fallout New Vegas Updated" mod by "MonochromeWench - Hendricks266 - Roy Batty".

The idea is to revert back the changes of the Large Address Aware patch so it passes the integrity check. The file integrity check is bypassed by redirecting to an unmodified file.

Seems to work fine, but I've only experimented a little bit. I don't know if the game itself can properly handle 2GB+ addresses. Needs experimentation, I suppose.

Fixes #48 