### PR TITLE
Properly manage D3D9 objects i.e. proper reference count

### DIFF
--- a/Common/Logger.h
+++ b/Common/Logger.h
@@ -21,7 +21,7 @@ public:
 
 	Logger() : m_systime(), m_console(INVALID_HANDLE_VALUE), m_file(INVALID_HANDLE_VALUE)  {}
 
-	Logger::~Logger()
+	virtual ~Logger()
 	{
 		if (m_console)
 			FreeConsole();
@@ -34,7 +34,7 @@ public:
 	std::mutex& writeMutex() const { return m_writeMutex; }
 #endif
 
-	static Logger& Logger::Get()
+	static Logger& Get()
 	{
 		static Logger instance;
 		return instance;

--- a/Common/SimpleIni.h
+++ b/Common/SimpleIni.h
@@ -328,16 +328,16 @@ public:
 #endif
 
         /** Strict less ordering by name of key only */
-        struct KeyOrder : std::binary_function<Entry, Entry, bool> {
-            bool operator()(const Entry & lhs, const Entry & rhs) const {
+        struct KeyOrder {
+            bool operator()(const Entry& lhs, const Entry& rhs) const {
                 const static SI_STRLESS isLess = SI_STRLESS();
                 return isLess(lhs.pItem, rhs.pItem);
             }
         };
 
         /** Strict less ordering by order, and then name of key */
-        struct LoadOrder : std::binary_function<Entry, Entry, bool> {
-            bool operator()(const Entry & lhs, const Entry & rhs) const {
+        struct LoadOrder {
+            bool operator()(const Entry& lhs, const Entry& rhs) const {
                 if (lhs.nOrder != rhs.nOrder) {
                     return lhs.nOrder < rhs.nOrder;
                 }

--- a/Common/StringUtil.h
+++ b/Common/StringUtil.h
@@ -149,13 +149,13 @@ inline std::string CP1252ToUTF8(const std::string& input)
 
 // trim from start
 static inline std::string &ltrim(std::string &s) {
-	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not_fn(std::isspace)));
 	return s;
 }
 
 // trim from end
 static inline std::string &rtrim(std::string &s) {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+	s.erase(std::find_if(s.rbegin(), s.rend(), std::not_fn(std::isspace)).base(), s.end());
 	return s;
 }
 

--- a/d3d9ex/Context.h
+++ b/d3d9ex/Context.h
@@ -34,6 +34,7 @@ class MainContext
 	const MainContext& operator=(MainContext& other) = delete;
 
 	DECLARE_HOOK(IDirect3D9*, WINAPI, Direct3DCreate9, UINT SDKVersion);
+	DECLARE_HOOK(HRESULT, WINAPI, Direct3DCreate9Ex, UINT SDKVersion, IDirect3D9Ex** ppIDirect3D9Ex);
 	DECLARE_HOOK(LONG, WINAPI, SetWindowLongA, HWND hWnd, int nIndex, LONG dwNewLong);
 	DECLARE_HOOK(LONG, WINAPI, SetWindowLongW, HWND hWnd, int nIndex, LONG dwNewLong);
 	DECLARE_HOOK(HWND, WINAPI, CreateWindowExA, DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName,
@@ -77,6 +78,9 @@ private:
 	HWND hWndFF13 = 0;
 
 	std::mutex fix_mutex;
+
+	//MainContext is global!
+	//TODO this class is cluttered, separate fixes class from MainContext
 
 	const float MAX_FRAME_RATE_LIMIT = 250000.0F;
 	float** ff13_frame_pacer_ptr = NULL;

--- a/d3d9ex/IDirect3D9.h
+++ b/d3d9ex/IDirect3D9.h
@@ -1,65 +1,52 @@
-// wrapper for IDirect3D9 in d3d9.h
-// generated using wrapper_gen.rb
-
+#pragma once
 #include <d3d9.h>
 
-#include "IDirect3DDevice9.h"
-
-interface hkIDirect3D9 final : public IDirect3D9 {
+interface DECLSPEC_UUID("16760376-B89E-4CD9-9CE1-5B1C7AFC2E16") hkIDirect3D9 final : public IDirect3D9Ex{
 public:
-	// original interface
-	STDMETHOD(QueryInterface)(REFIID riid, void** ppvObj);
-	ULONG STDMETHODCALLTYPE AddRef() {
-		m_refPrivate++;
-		m_refCount = m_pWrapped->AddRef();
-		if (m_refCount > m_refPrivate) {
-			// you should not see this ever
-			PrintLog("WARNING: Internal reference counting to low, adjusting %u->%u", m_refPrivate.load(), m_refCount.load());
-			m_refPrivate = m_refCount + 1;
-		}
+	#pragma region IUnknown
+	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj);
+	ULONG STDMETHODCALLTYPE AddRef();
+	ULONG STDMETHODCALLTYPE Release();
+	#pragma endregion
+	#pragma region IDirect3D9
+	HRESULT STDMETHODCALLTYPE RegisterSoftwareDevice(void* pInitializeFunction);
+	UINT STDMETHODCALLTYPE GetAdapterCount();
+	HRESULT STDMETHODCALLTYPE GetAdapterIdentifier(UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER9* pIdentifier);
+	UINT STDMETHODCALLTYPE GetAdapterModeCount(UINT Adapter, D3DFORMAT Format);
+	HRESULT STDMETHODCALLTYPE EnumAdapterModes(UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE* pMode);
+	HRESULT STDMETHODCALLTYPE GetAdapterDisplayMode(UINT Adapter, D3DDISPLAYMODE* pMode);
+	HRESULT STDMETHODCALLTYPE CheckDeviceType(UINT Adapter, D3DDEVTYPE DevType, D3DFORMAT AdapterFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed);
+	HRESULT STDMETHODCALLTYPE CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat);
+	HRESULT STDMETHODCALLTYPE CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType, DWORD* pQualityLevels);
+	HRESULT STDMETHODCALLTYPE CheckDepthStencilMatch(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat);
+	HRESULT STDMETHODCALLTYPE CheckDeviceFormatConversion(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SourceFormat, D3DFORMAT TargetFormat);
+	HRESULT STDMETHODCALLTYPE GetDeviceCaps(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS9* pCaps);
+	HMONITOR STDMETHODCALLTYPE GetAdapterMonitor(UINT Adapter);
+	HRESULT STDMETHODCALLTYPE CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface);
+	#pragma endregion
+	#pragma region IDirect3D9Ex
+	UINT STDMETHODCALLTYPE GetAdapterModeCountEx(UINT Adapter, const D3DDISPLAYMODEFILTER* pFilter);
+	HRESULT STDMETHODCALLTYPE EnumAdapterModesEx(UINT Adapter, const D3DDISPLAYMODEFILTER* pFilter, UINT Mode, D3DDISPLAYMODEEX* pMode);
+	HRESULT STDMETHODCALLTYPE GetAdapterDisplayModeEx(UINT Adapter, D3DDISPLAYMODEEX* pMode, D3DDISPLAYROTATION* pRotation);
+	HRESULT STDMETHODCALLTYPE CreateDeviceEx(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode, IDirect3DDevice9Ex** ppReturnedDeviceInterface);
+	HRESULT STDMETHODCALLTYPE GetAdapterLUID(UINT Adapter, LUID* pLUID);
+	#pragma endregion
 
-		return m_refCount + 1;
-	}
-
-	ULONG STDMETHODCALLTYPE Release() {
-		if (m_refPrivate == 0ul)
-			delete this;
-
-		if (m_refPrivate != 0ul) {
-			m_refPrivate--;
-
-			m_refCount = m_pWrapped->Release();
-		}
-		return m_refCount + 1;
-	}
-	STDMETHOD(RegisterSoftwareDevice)(void* pInitializeFunction);
-	STDMETHOD_(UINT, GetAdapterCount)();
-	STDMETHOD(GetAdapterIdentifier)(UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER9* pIdentifier);
-	STDMETHOD_(UINT, GetAdapterModeCount)(UINT Adapter, D3DFORMAT Format);
-	STDMETHOD(EnumAdapterModes)(UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE* pMode);
-	STDMETHOD(GetAdapterDisplayMode)(UINT Adapter, D3DDISPLAYMODE* pMode);
-	STDMETHOD(CheckDeviceType)(UINT Adapter, D3DDEVTYPE DevType, D3DFORMAT AdapterFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed);
-	STDMETHOD(CheckDeviceFormat)(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat);
-	STDMETHOD(CheckDeviceMultiSampleType)(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType, DWORD* pQualityLevels);
-	STDMETHOD(CheckDepthStencilMatch)(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat);
-	STDMETHOD(CheckDeviceFormatConversion)(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SourceFormat, D3DFORMAT TargetFormat);
-	STDMETHOD(GetDeviceCaps)(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS9* pCaps);
-	STDMETHOD_(HMONITOR, GetAdapterMonitor)(UINT Adapter);
-	STDMETHOD(CreateDevice)(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface);
-
-
-	hkIDirect3D9(IDirect3D9* pIDirect3D9)
+	hkIDirect3D9(IDirect3D9Ex* pIDirect3D9)
 		: m_pWrapped(pIDirect3D9)
 	{
 	}
 
-	virtual ~hkIDirect3D9(){while (m_pWrapped->Release());}
-
+	virtual ~hkIDirect3D9() { }
 
 private:
-	IDirect3D9* m_pWrapped;
-    std::atomic<uint32_t> m_refCount = { 0ul };
-    std::atomic<uint32_t> m_refPrivate = { 1ul };
+	IDirect3D9Ex* m_pWrapped;
+	ULONG m_ref = 1;
+	bool m_is_ex = false;
+
+	template <typename T, bool ex>
+	HRESULT ApplyCreateDeviceFix(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode, T** ppReturnedDeviceInterface);
+
 };
 
 

--- a/d3d9ex/IDirect3DDevice9.h
+++ b/d3d9ex/IDirect3DDevice9.h
@@ -1,163 +1,159 @@
-// wrapper for IDirect3DDevice9 in d3d9.h
-// generated using wrapper_gen.rb
-
 #pragma once
 #include <d3d9.h>
 
-interface hkIDirect3DDevice9 final : public IDirect3DDevice9 {
+interface DECLSPEC_UUID("DD98C5F4-40E6-43D9-A0EA-0C32ABDFDF9C") hkIDirect3DDevice9 final : public IDirect3DDevice9Ex{
 public:
-	// original interface
-	STDMETHOD(QueryInterface)(REFIID riid, void** ppvObj);
-	ULONG STDMETHODCALLTYPE AddRef() {
-		m_refPrivate++;
-		m_refCount = m_pWrapped->AddRef();
-		if (m_refCount > m_refPrivate) {
-			// you should not see this ever
-			PrintLog("WARNING: Internal reference counting to low, adjusting %u->%u", m_refPrivate.load(), m_refCount.load());
-			m_refPrivate = m_refCount + 1;
-		}
+	#pragma region IUnknown
+	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj);
+	ULONG STDMETHODCALLTYPE AddRef();
+	ULONG STDMETHODCALLTYPE Release();
+	#pragma endregion
+	#pragma region IDirect3DDevice9
+	HRESULT STDMETHODCALLTYPE TestCooperativeLevel();
+	UINT STDMETHODCALLTYPE GetAvailableTextureMem();
+	HRESULT STDMETHODCALLTYPE EvictManagedResources();
+	HRESULT STDMETHODCALLTYPE GetDirect3D(IDirect3D9** ppD3D9);
+	HRESULT STDMETHODCALLTYPE GetDeviceCaps(D3DCAPS9* pCaps);
+	HRESULT STDMETHODCALLTYPE GetDisplayMode(UINT iSwapChain, D3DDISPLAYMODE* pMode);
+	HRESULT STDMETHODCALLTYPE GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS* pParameters);
+	HRESULT STDMETHODCALLTYPE SetCursorProperties(UINT XHotSpot, UINT YHotSpot, IDirect3DSurface9* pCursorBitmap);
+	void STDMETHODCALLTYPE SetCursorPosition(int X, int Y, DWORD Flags);
+	BOOL STDMETHODCALLTYPE ShowCursor(BOOL bShow);
+	HRESULT STDMETHODCALLTYPE CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DSwapChain9** pSwapChain);
+	HRESULT STDMETHODCALLTYPE GetSwapChain(UINT iSwapChain, IDirect3DSwapChain9** pSwapChain);
+	UINT STDMETHODCALLTYPE GetNumberOfSwapChains();
+	HRESULT STDMETHODCALLTYPE Reset(D3DPRESENT_PARAMETERS* pPresentationParameters);
+	HRESULT STDMETHODCALLTYPE Present(CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride, CONST RGNDATA* pDirtyRegion);
+	HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9** ppBackBuffer);
+	HRESULT STDMETHODCALLTYPE GetRasterStatus(UINT iSwapChain, D3DRASTER_STATUS* pRasterStatus);
+	HRESULT STDMETHODCALLTYPE SetDialogBoxMode(BOOL bEnableDialogs);
+	void STDMETHODCALLTYPE SetGammaRamp(UINT iSwapChain, DWORD Flags, CONST D3DGAMMARAMP* pRamp);
+	void STDMETHODCALLTYPE GetGammaRamp(UINT iSwapChain, D3DGAMMARAMP* pRamp);
+	HRESULT STDMETHODCALLTYPE CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9** ppTexture, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture9** ppVolumeTexture, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture9** ppCubeTexture, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9** ppVertexBuffer, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer9** ppIndexBuffer, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Discard, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE UpdateSurface(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestinationSurface, CONST POINT* pDestPoint);
+	HRESULT STDMETHODCALLTYPE UpdateTexture(IDirect3DBaseTexture9* pSourceTexture, IDirect3DBaseTexture9* pDestinationTexture);
+	HRESULT STDMETHODCALLTYPE GetRenderTargetData(IDirect3DSurface9* pRenderTarget, IDirect3DSurface9* pDestSurface);
+	HRESULT STDMETHODCALLTYPE GetFrontBufferData(UINT iSwapChain, IDirect3DSurface9* pDestSurface);
+	HRESULT STDMETHODCALLTYPE StretchRect(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface, CONST RECT* pDestRect, D3DTEXTUREFILTERTYPE Filter);
+	HRESULT STDMETHODCALLTYPE ColorFill(IDirect3DSurface9* pSurface, CONST RECT* pRect, D3DCOLOR color);
+	HRESULT STDMETHODCALLTYPE CreateOffscreenPlainSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DPOOL Pool, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle);
+	HRESULT STDMETHODCALLTYPE SetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9* pRenderTarget);
+	HRESULT STDMETHODCALLTYPE GetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9** ppRenderTarget);
+	HRESULT STDMETHODCALLTYPE SetDepthStencilSurface(IDirect3DSurface9* pNewZStencil);
+	HRESULT STDMETHODCALLTYPE GetDepthStencilSurface(IDirect3DSurface9** ppZStencilSurface);
+	HRESULT STDMETHODCALLTYPE BeginScene();
+	HRESULT STDMETHODCALLTYPE EndScene();
+	HRESULT STDMETHODCALLTYPE Clear(DWORD Count, CONST D3DRECT* pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil);
+	HRESULT STDMETHODCALLTYPE SetTransform(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX* pMatrix);
+	HRESULT STDMETHODCALLTYPE GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX* pMatrix);
+	HRESULT STDMETHODCALLTYPE MultiplyTransform(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX* pMatrix);
+	HRESULT STDMETHODCALLTYPE SetViewport(CONST D3DVIEWPORT9* pViewport);
+	HRESULT STDMETHODCALLTYPE GetViewport(D3DVIEWPORT9* pViewport);
+	HRESULT STDMETHODCALLTYPE SetMaterial(CONST D3DMATERIAL9* pMaterial);
+	HRESULT STDMETHODCALLTYPE GetMaterial(D3DMATERIAL9* pMaterial);
+	HRESULT STDMETHODCALLTYPE SetLight(DWORD Index, CONST D3DLIGHT9* pLight);
+	HRESULT STDMETHODCALLTYPE GetLight(DWORD Index, D3DLIGHT9* pLight);
+	HRESULT STDMETHODCALLTYPE LightEnable(DWORD Index, BOOL Enable);
+	HRESULT STDMETHODCALLTYPE GetLightEnable(DWORD Index, BOOL* pEnable);
+	HRESULT STDMETHODCALLTYPE SetClipPlane(DWORD Index, CONST float* pPlane);
+	HRESULT STDMETHODCALLTYPE GetClipPlane(DWORD Index, float* pPlane);
+	HRESULT STDMETHODCALLTYPE SetRenderState(D3DRENDERSTATETYPE State, DWORD Value);
+	HRESULT STDMETHODCALLTYPE GetRenderState(D3DRENDERSTATETYPE State, DWORD* pValue);
+	HRESULT STDMETHODCALLTYPE CreateStateBlock(D3DSTATEBLOCKTYPE Type, IDirect3DStateBlock9** ppSB);
+	HRESULT STDMETHODCALLTYPE BeginStateBlock();
+	HRESULT STDMETHODCALLTYPE EndStateBlock(IDirect3DStateBlock9** ppSB);
+	HRESULT STDMETHODCALLTYPE SetClipStatus(CONST D3DCLIPSTATUS9* pClipStatus);
+	HRESULT STDMETHODCALLTYPE GetClipStatus(D3DCLIPSTATUS9* pClipStatus);
+	HRESULT STDMETHODCALLTYPE GetTexture(DWORD Stage, IDirect3DBaseTexture9** ppTexture);
+	HRESULT STDMETHODCALLTYPE SetTexture(DWORD Stage, IDirect3DBaseTexture9* pTexture);
+	HRESULT STDMETHODCALLTYPE GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD* pValue);
+	HRESULT STDMETHODCALLTYPE SetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value);
+	HRESULT STDMETHODCALLTYPE GetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD* pValue);
+	HRESULT STDMETHODCALLTYPE SetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value);
+	HRESULT STDMETHODCALLTYPE ValidateDevice(DWORD* pNumPasses);
+	HRESULT STDMETHODCALLTYPE SetPaletteEntries(UINT PaletteNumber, CONST PALETTEENTRY* pEntries);
+	HRESULT STDMETHODCALLTYPE GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY* pEntries);
+	HRESULT STDMETHODCALLTYPE SetCurrentTexturePalette(UINT PaletteNumber);
+	HRESULT STDMETHODCALLTYPE GetCurrentTexturePalette(UINT* PaletteNumber);
+	HRESULT STDMETHODCALLTYPE SetScissorRect(CONST RECT* pRect);
+	HRESULT STDMETHODCALLTYPE GetScissorRect(RECT* pRect);
+	HRESULT STDMETHODCALLTYPE SetSoftwareVertexProcessing(BOOL bSoftware);
+	BOOL STDMETHODCALLTYPE GetSoftwareVertexProcessing();
+	HRESULT STDMETHODCALLTYPE SetNPatchMode(float nSegments);
+	float STDMETHODCALLTYPE GetNPatchMode();
+	HRESULT STDMETHODCALLTYPE DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount);
+	HRESULT STDMETHODCALLTYPE DrawIndexedPrimitive(D3DPRIMITIVETYPE, INT BaseVertexIndex, UINT MinVertexIndex, UINT NumVertices, UINT startIndex, UINT primCount);
+	HRESULT STDMETHODCALLTYPE DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
+	HRESULT STDMETHODCALLTYPE DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount, CONST void* pIndexData, D3DFORMAT IndexDataFormat, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
+	HRESULT STDMETHODCALLTYPE ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer9* pDestBuffer, IDirect3DVertexDeclaration9* pVertexDecl, DWORD Flags);
+	HRESULT STDMETHODCALLTYPE CreateVertexDeclaration(CONST D3DVERTEXELEMENT9* pVertexElements, IDirect3DVertexDeclaration9** ppDecl);
+	HRESULT STDMETHODCALLTYPE SetVertexDeclaration(IDirect3DVertexDeclaration9* pDecl);
+	HRESULT STDMETHODCALLTYPE GetVertexDeclaration(IDirect3DVertexDeclaration9** ppDecl);
+	HRESULT STDMETHODCALLTYPE SetFVF(DWORD FVF);
+	HRESULT STDMETHODCALLTYPE GetFVF(DWORD* pFVF);
+	HRESULT STDMETHODCALLTYPE CreateVertexShader(CONST DWORD* pFunction, IDirect3DVertexShader9** ppShader);
+	HRESULT STDMETHODCALLTYPE SetVertexShader(IDirect3DVertexShader9* pShader);
+	HRESULT STDMETHODCALLTYPE GetVertexShader(IDirect3DVertexShader9** ppShader);
+	HRESULT STDMETHODCALLTYPE SetVertexShaderConstantF(UINT StartRegister, CONST float* pConstantData, UINT Vector4fCount);
+	HRESULT STDMETHODCALLTYPE GetVertexShaderConstantF(UINT StartRegister, float* pConstantData, UINT Vector4fCount);
+	HRESULT STDMETHODCALLTYPE SetVertexShaderConstantI(UINT StartRegister, CONST int* pConstantData, UINT Vector4iCount);
+	HRESULT STDMETHODCALLTYPE GetVertexShaderConstantI(UINT StartRegister, int* pConstantData, UINT Vector4iCount);
+	HRESULT STDMETHODCALLTYPE SetVertexShaderConstantB(UINT StartRegister, CONST BOOL* pConstantData, UINT  BoolCount);
+	HRESULT STDMETHODCALLTYPE GetVertexShaderConstantB(UINT StartRegister, BOOL* pConstantData, UINT BoolCount);
+	HRESULT STDMETHODCALLTYPE SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer9* pStreamData, UINT OffsetInBytes, UINT Stride);
+	HRESULT STDMETHODCALLTYPE GetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer9** ppStreamData, UINT* pOffsetInBytes, UINT* pStride);
+	HRESULT STDMETHODCALLTYPE SetStreamSourceFreq(UINT StreamNumber, UINT Setting);
+	HRESULT STDMETHODCALLTYPE GetStreamSourceFreq(UINT StreamNumber, UINT* pSetting);
+	HRESULT STDMETHODCALLTYPE SetIndices(IDirect3DIndexBuffer9* pIndexData);
+	HRESULT STDMETHODCALLTYPE GetIndices(IDirect3DIndexBuffer9** ppIndexData);
+	HRESULT STDMETHODCALLTYPE CreatePixelShader(CONST DWORD* pFunction, IDirect3DPixelShader9** ppShader);
+	HRESULT STDMETHODCALLTYPE SetPixelShader(IDirect3DPixelShader9* pShader);
+	HRESULT STDMETHODCALLTYPE GetPixelShader(IDirect3DPixelShader9** ppShader);
+	HRESULT STDMETHODCALLTYPE SetPixelShaderConstantF(UINT StartRegister, CONST float* pConstantData, UINT Vector4fCount);
+	HRESULT STDMETHODCALLTYPE GetPixelShaderConstantF(UINT StartRegister, float* pConstantData, UINT Vector4fCount);
+	HRESULT STDMETHODCALLTYPE SetPixelShaderConstantI(UINT StartRegister, CONST int* pConstantData, UINT Vector4iCount);
+	HRESULT STDMETHODCALLTYPE GetPixelShaderConstantI(UINT StartRegister, int* pConstantData, UINT Vector4iCount);
+	HRESULT STDMETHODCALLTYPE SetPixelShaderConstantB(UINT StartRegister, CONST BOOL* pConstantData, UINT  BoolCount);
+	HRESULT STDMETHODCALLTYPE GetPixelShaderConstantB(UINT StartRegister, BOOL* pConstantData, UINT BoolCount);
+	HRESULT STDMETHODCALLTYPE DrawRectPatch(UINT Handle, CONST float* pNumSegs, CONST D3DRECTPATCH_INFO* pRectPatchInfo);
+	HRESULT STDMETHODCALLTYPE DrawTriPatch(UINT Handle, CONST float* pNumSegs, CONST D3DTRIPATCH_INFO* pTriPatchInfo);
+	HRESULT STDMETHODCALLTYPE DeletePatch(UINT Handle);
+	HRESULT STDMETHODCALLTYPE CreateQuery(D3DQUERYTYPE Type, IDirect3DQuery9** ppQuery);
+	#pragma endregion
+	#pragma region IDirect3DDevice9Ex
+	HRESULT STDMETHODCALLTYPE SetConvolutionMonoKernel(THIS_ UINT width, UINT height, float* rows, float* columns);
+	HRESULT STDMETHODCALLTYPE ComposeRects(THIS_ IDirect3DSurface9* pSrc, IDirect3DSurface9* pDst, IDirect3DVertexBuffer9* pSrcRectDescs, UINT NumRects, IDirect3DVertexBuffer9* pDstRectDescs, D3DCOMPOSERECTSOP Operation, int Xoffset, int Yoffset);
+	HRESULT STDMETHODCALLTYPE PresentEx(THIS_ CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride, CONST RGNDATA* pDirtyRegion, DWORD dwFlags);
+	HRESULT STDMETHODCALLTYPE GetGPUThreadPriority(THIS_ INT* pPriority);
+	HRESULT STDMETHODCALLTYPE SetGPUThreadPriority(THIS_ INT Priority);
+	HRESULT STDMETHODCALLTYPE WaitForVBlank(THIS_ UINT iSwapChain);
+	HRESULT STDMETHODCALLTYPE CheckResourceResidency(THIS_ IDirect3DResource9** pResourceArray, UINT32 NumResources);
+	HRESULT STDMETHODCALLTYPE SetMaximumFrameLatency(THIS_ UINT MaxLatency);
+	HRESULT STDMETHODCALLTYPE GetMaximumFrameLatency(THIS_ UINT* pMaxLatency);
+	HRESULT STDMETHODCALLTYPE CheckDeviceState(THIS_ HWND hDestinationWindow);
+	HRESULT STDMETHODCALLTYPE CreateRenderTargetEx(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle, DWORD Usage);
+	HRESULT STDMETHODCALLTYPE CreateOffscreenPlainSurfaceEx(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DPOOL Pool, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle, DWORD Usage);
+	HRESULT STDMETHODCALLTYPE CreateDepthStencilSurfaceEx(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Discard, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle, DWORD Usage);
+	HRESULT STDMETHODCALLTYPE ResetEx(THIS_ D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode);
+	HRESULT STDMETHODCALLTYPE GetDisplayModeEx(THIS_ UINT iSwapChain, D3DDISPLAYMODEEX* pMode, D3DDISPLAYROTATION* pRotation);
+	#pragma endregion
 
-		return m_refCount + 1;
-	}
-
-	ULONG STDMETHODCALLTYPE Release() {
-		if (m_refPrivate == 0ul)
-			delete this;
-
-		if (m_refPrivate != 0ul) {
-			m_refPrivate--;
-
-			m_refCount = m_pWrapped->Release();
-		}
-		return m_refCount + 1;
-	}
-	STDMETHOD(TestCooperativeLevel)();
-	STDMETHOD_(UINT, GetAvailableTextureMem)();
-	STDMETHOD(EvictManagedResources)();
-	STDMETHOD(GetDirect3D)(IDirect3D9** ppD3D9);
-	STDMETHOD(GetDeviceCaps)(D3DCAPS9* pCaps);
-	STDMETHOD(GetDisplayMode)(UINT iSwapChain, D3DDISPLAYMODE* pMode);
-	STDMETHOD(GetCreationParameters)(D3DDEVICE_CREATION_PARAMETERS* pParameters);
-	STDMETHOD(SetCursorProperties)(UINT XHotSpot, UINT YHotSpot, IDirect3DSurface9* pCursorBitmap);
-	STDMETHOD_(void, SetCursorPosition)(int X, int Y, DWORD Flags);
-	STDMETHOD_(BOOL, ShowCursor)(BOOL bShow);
-	STDMETHOD(CreateAdditionalSwapChain)(D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DSwapChain9** pSwapChain);
-	STDMETHOD(GetSwapChain)(UINT iSwapChain, IDirect3DSwapChain9** pSwapChain);
-	STDMETHOD_(UINT, GetNumberOfSwapChains)();
-	STDMETHOD(Reset)(D3DPRESENT_PARAMETERS* pPresentationParameters);
-	STDMETHOD(Present)(CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride, CONST RGNDATA* pDirtyRegion);
-	STDMETHOD(GetBackBuffer)(UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9** ppBackBuffer);
-	STDMETHOD(GetRasterStatus)(UINT iSwapChain, D3DRASTER_STATUS* pRasterStatus);
-	STDMETHOD(SetDialogBoxMode)(BOOL bEnableDialogs);
-	STDMETHOD_(void, SetGammaRamp)(UINT iSwapChain, DWORD Flags, CONST D3DGAMMARAMP* pRamp);
-	STDMETHOD_(void, GetGammaRamp)(UINT iSwapChain, D3DGAMMARAMP* pRamp);
-	STDMETHOD(CreateTexture)(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9** ppTexture, HANDLE* pSharedHandle);
-	STDMETHOD(CreateVolumeTexture)(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture9** ppVolumeTexture, HANDLE* pSharedHandle);
-	STDMETHOD(CreateCubeTexture)(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture9** ppCubeTexture, HANDLE* pSharedHandle);
-	STDMETHOD(CreateVertexBuffer)(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9** ppVertexBuffer, HANDLE* pSharedHandle);
-	STDMETHOD(CreateIndexBuffer)(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer9** ppIndexBuffer, HANDLE* pSharedHandle);
-	STDMETHOD(CreateRenderTarget)(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle);
-	STDMETHOD(CreateDepthStencilSurface)(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Discard, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle);
-	STDMETHOD(UpdateSurface)(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestinationSurface, CONST POINT* pDestPoint);
-	STDMETHOD(UpdateTexture)(IDirect3DBaseTexture9* pSourceTexture, IDirect3DBaseTexture9* pDestinationTexture);
-	STDMETHOD(GetRenderTargetData)(IDirect3DSurface9* pRenderTarget, IDirect3DSurface9* pDestSurface);
-	STDMETHOD(GetFrontBufferData)(UINT iSwapChain, IDirect3DSurface9* pDestSurface);
-	STDMETHOD(StretchRect)(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface, CONST RECT* pDestRect, D3DTEXTUREFILTERTYPE Filter);
-	STDMETHOD(ColorFill)(IDirect3DSurface9* pSurface, CONST RECT* pRect, D3DCOLOR color);
-	STDMETHOD(CreateOffscreenPlainSurface)(UINT Width, UINT Height, D3DFORMAT Format, D3DPOOL Pool, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle);
-	STDMETHOD(SetRenderTarget)(DWORD RenderTargetIndex, IDirect3DSurface9* pRenderTarget);
-	STDMETHOD(GetRenderTarget)(DWORD RenderTargetIndex, IDirect3DSurface9** ppRenderTarget);
-	STDMETHOD(SetDepthStencilSurface)(IDirect3DSurface9* pNewZStencil);
-	STDMETHOD(GetDepthStencilSurface)(IDirect3DSurface9** ppZStencilSurface);
-	STDMETHOD(BeginScene)();
-	STDMETHOD(EndScene)();
-	STDMETHOD(Clear)(DWORD Count, CONST D3DRECT* pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil);
-	STDMETHOD(SetTransform)(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX* pMatrix);
-	STDMETHOD(GetTransform)(D3DTRANSFORMSTATETYPE State, D3DMATRIX* pMatrix);
-	STDMETHOD(MultiplyTransform)(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX* pMatrix);
-	STDMETHOD(SetViewport)(CONST D3DVIEWPORT9* pViewport);
-	STDMETHOD(GetViewport)(D3DVIEWPORT9* pViewport);
-	STDMETHOD(SetMaterial)(CONST D3DMATERIAL9* pMaterial);
-	STDMETHOD(GetMaterial)(D3DMATERIAL9* pMaterial);
-	STDMETHOD(SetLight)(DWORD Index, CONST D3DLIGHT9* pLight);
-	STDMETHOD(GetLight)(DWORD Index, D3DLIGHT9* pLight);
-	STDMETHOD(LightEnable)(DWORD Index, BOOL Enable);
-	STDMETHOD(GetLightEnable)(DWORD Index, BOOL* pEnable);
-	STDMETHOD(SetClipPlane)(DWORD Index, CONST float* pPlane);
-	STDMETHOD(GetClipPlane)(DWORD Index, float* pPlane);
-	STDMETHOD(SetRenderState)(D3DRENDERSTATETYPE State, DWORD Value);
-	STDMETHOD(GetRenderState)(D3DRENDERSTATETYPE State, DWORD* pValue);
-	STDMETHOD(CreateStateBlock)(D3DSTATEBLOCKTYPE Type, IDirect3DStateBlock9** ppSB);
-	STDMETHOD(BeginStateBlock)();
-	STDMETHOD(EndStateBlock)(IDirect3DStateBlock9** ppSB);
-	STDMETHOD(SetClipStatus)(CONST D3DCLIPSTATUS9* pClipStatus);
-	STDMETHOD(GetClipStatus)(D3DCLIPSTATUS9* pClipStatus);
-	STDMETHOD(GetTexture)(DWORD Stage, IDirect3DBaseTexture9** ppTexture);
-	STDMETHOD(SetTexture)(DWORD Stage, IDirect3DBaseTexture9* pTexture);
-	STDMETHOD(GetTextureStageState)(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD* pValue);
-	STDMETHOD(SetTextureStageState)(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value);
-	STDMETHOD(GetSamplerState)(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD* pValue);
-	STDMETHOD(SetSamplerState)(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value);
-	STDMETHOD(ValidateDevice)(DWORD* pNumPasses);
-	STDMETHOD(SetPaletteEntries)(UINT PaletteNumber, CONST PALETTEENTRY* pEntries);
-	STDMETHOD(GetPaletteEntries)(UINT PaletteNumber, PALETTEENTRY* pEntries);
-	STDMETHOD(SetCurrentTexturePalette)(UINT PaletteNumber);
-	STDMETHOD(GetCurrentTexturePalette)(UINT* PaletteNumber);
-	STDMETHOD(SetScissorRect)(CONST RECT* pRect);
-	STDMETHOD(GetScissorRect)(RECT* pRect);
-	STDMETHOD(SetSoftwareVertexProcessing)(BOOL bSoftware);
-	STDMETHOD_(BOOL, GetSoftwareVertexProcessing)();
-	STDMETHOD(SetNPatchMode)(float nSegments);
-	STDMETHOD_(float, GetNPatchMode)();
-	STDMETHOD(DrawPrimitive)(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount);
-	STDMETHOD(DrawIndexedPrimitive)(D3DPRIMITIVETYPE, INT BaseVertexIndex, UINT MinVertexIndex, UINT NumVertices, UINT startIndex, UINT primCount);
-	STDMETHOD(DrawPrimitiveUP)(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
-	STDMETHOD(DrawIndexedPrimitiveUP)(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount, CONST void* pIndexData, D3DFORMAT IndexDataFormat, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
-	STDMETHOD(ProcessVertices)(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer9* pDestBuffer, IDirect3DVertexDeclaration9* pVertexDecl, DWORD Flags);
-	STDMETHOD(CreateVertexDeclaration)(CONST D3DVERTEXELEMENT9* pVertexElements, IDirect3DVertexDeclaration9** ppDecl);
-	STDMETHOD(SetVertexDeclaration)(IDirect3DVertexDeclaration9* pDecl);
-	STDMETHOD(GetVertexDeclaration)(IDirect3DVertexDeclaration9** ppDecl);
-	STDMETHOD(SetFVF)(DWORD FVF);
-	STDMETHOD(GetFVF)(DWORD* pFVF);
-	STDMETHOD(CreateVertexShader)(CONST DWORD* pFunction, IDirect3DVertexShader9** ppShader);
-	STDMETHOD(SetVertexShader)(IDirect3DVertexShader9* pShader);
-	STDMETHOD(GetVertexShader)(IDirect3DVertexShader9** ppShader);
-	STDMETHOD(SetVertexShaderConstantF)(UINT StartRegister, CONST float* pConstantData, UINT Vector4fCount);
-	STDMETHOD(GetVertexShaderConstantF)(UINT StartRegister, float* pConstantData, UINT Vector4fCount);
-	STDMETHOD(SetVertexShaderConstantI)(UINT StartRegister, CONST int* pConstantData, UINT Vector4iCount);
-	STDMETHOD(GetVertexShaderConstantI)(UINT StartRegister, int* pConstantData, UINT Vector4iCount);
-	STDMETHOD(SetVertexShaderConstantB)(UINT StartRegister, CONST BOOL* pConstantData, UINT  BoolCount);
-	STDMETHOD(GetVertexShaderConstantB)(UINT StartRegister, BOOL* pConstantData, UINT BoolCount);
-	STDMETHOD(SetStreamSource)(UINT StreamNumber, IDirect3DVertexBuffer9* pStreamData, UINT OffsetInBytes, UINT Stride);
-	STDMETHOD(GetStreamSource)(UINT StreamNumber, IDirect3DVertexBuffer9** ppStreamData, UINT* pOffsetInBytes, UINT* pStride);
-	STDMETHOD(SetStreamSourceFreq)(UINT StreamNumber, UINT Setting);
-	STDMETHOD(GetStreamSourceFreq)(UINT StreamNumber, UINT* pSetting);
-	STDMETHOD(SetIndices)(IDirect3DIndexBuffer9* pIndexData);
-	STDMETHOD(GetIndices)(IDirect3DIndexBuffer9** ppIndexData);
-	STDMETHOD(CreatePixelShader)(CONST DWORD* pFunction, IDirect3DPixelShader9** ppShader);
-	STDMETHOD(SetPixelShader)(IDirect3DPixelShader9* pShader);
-	STDMETHOD(GetPixelShader)(IDirect3DPixelShader9** ppShader);
-	STDMETHOD(SetPixelShaderConstantF)(UINT StartRegister, CONST float* pConstantData, UINT Vector4fCount);
-	STDMETHOD(GetPixelShaderConstantF)(UINT StartRegister, float* pConstantData, UINT Vector4fCount);
-	STDMETHOD(SetPixelShaderConstantI)(UINT StartRegister, CONST int* pConstantData, UINT Vector4iCount);
-	STDMETHOD(GetPixelShaderConstantI)(UINT StartRegister, int* pConstantData, UINT Vector4iCount);
-	STDMETHOD(SetPixelShaderConstantB)(UINT StartRegister, CONST BOOL* pConstantData, UINT  BoolCount);
-	STDMETHOD(GetPixelShaderConstantB)(UINT StartRegister, BOOL* pConstantData, UINT BoolCount);
-	STDMETHOD(DrawRectPatch)(UINT Handle, CONST float* pNumSegs, CONST D3DRECTPATCH_INFO* pRectPatchInfo);
-	STDMETHOD(DrawTriPatch)(UINT Handle, CONST float* pNumSegs, CONST D3DTRIPATCH_INFO* pTriPatchInfo);
-	STDMETHOD(DeletePatch)(UINT Handle);
-	STDMETHOD(CreateQuery)(D3DQUERYTYPE Type, IDirect3DQuery9** ppQuery);
-
-	hkIDirect3DDevice9(IDirect3DDevice9* pIDirect3DDevice9)
-		: m_pWrapped(pIDirect3DDevice9)
+	hkIDirect3DDevice9(IDirect3DDevice9Ex* pIDirect3DDevice9, bool is_ex)
+		: m_pWrapped(pIDirect3DDevice9), m_is_ex(is_ex)
 	{
 	}
 
-	virtual ~hkIDirect3DDevice9() { while (m_pWrapped->Release()); }
+	virtual ~hkIDirect3DDevice9() { }
 
 private:
-	IDirect3DDevice9* m_pWrapped;
-	std::atomic<uint32_t> m_refCount = { 0ul };
-	std::atomic<uint32_t> m_refPrivate = { 1ul };
+	IDirect3DDevice9Ex* m_pWrapped;
+	ULONG m_ref = 1;
+	bool m_is_ex = false;
 };
 

--- a/d3d9ex/VertexFix.cpp
+++ b/d3d9ex/VertexFix.cpp
@@ -20,7 +20,7 @@ namespace cinterface
 	{
 		if (pVertexBuffer->lpVtbl->Lock && TrueLock == nullptr)
 		{
-			PrintLog("WARINING: Experimental DiscardUIVertexBuffer enabled!");
+			PrintLog("WARNING: Experimental DiscardUIVertexBuffer enabled!");
 			const MH_STATUS createHookLock = MH_CreateHook(pVertexBuffer->lpVtbl->Lock, HookLock, reinterpret_cast<void**>(&TrueLock));
 			PrintLog("CreateHookLock = %d", createHookLock);
 			const MH_STATUS enableHookLock = MH_EnableHook(pVertexBuffer->lpVtbl->Lock);

--- a/d3d9ex/d3d9ex.vcxproj
+++ b/d3d9ex/d3d9ex.vcxproj
@@ -99,6 +99,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;D3D9EX_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -132,6 +133,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CreateHotpatchableImage>true</CreateHotpatchableImage>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
DXVK is little off with this, reference count of IDirect3DDevice9 is perfectly fine, but we need to count IDirect3DDevice9Ex too because IDirect3DDevice9 is superset of it.
All crashes related to this should be gone, this commit also include basic IDirect3DDevice9Ex interface implementation.