### PR TITLE
Create native XInput implementation

### DIFF
--- a/d3d9ex/IDirect3DSwapChain9Hook.cpp
+++ b/d3d9ex/IDirect3DSwapChain9Hook.cpp
@@ -1,0 +1,46 @@
+#define CINTERFACE
+#include <d3d9.h>
+
+#include "spdlog/spdlog.h"
+#include "MinHook.h"
+#include "XInputManager.h"
+
+namespace cinterface
+{
+	static XInputManager* pXInputManager;
+	static uint32_t* pff13ButtonPressed;
+	static float* pff13AnalogValues;
+
+	HRESULT(STDMETHODCALLTYPE* TruePresent)(IDirect3DSwapChain9* This, CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride, CONST RGNDATA* pDirtyRegion, DWORD dwFlags) = nullptr;
+
+	HRESULT STDMETHODCALLTYPE HookPresent(IDirect3DSwapChain9* This, CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride, CONST RGNDATA* pDirtyRegion, DWORD dwFlags)
+	{
+		HRESULT result = TruePresent(This, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);
+		if (pXInputManager != NULL) {
+			pXInputManager->ReadValues(pff13ButtonPressed, pff13AnalogValues);
+			pXInputManager->SendVibrationToController();
+		}
+		return result;
+	}
+
+	void InitHookPresent(IDirect3DSwapChain9* pDirect3DSwapChain9)
+	{
+		if (pDirect3DSwapChain9->lpVtbl->Present && TruePresent == nullptr)
+		{
+			spdlog::info("Enabling PresentHook!");
+			const MH_STATUS createHookPresent = MH_CreateHook(pDirect3DSwapChain9->lpVtbl->Present, HookPresent, reinterpret_cast<void**>(&TruePresent));
+			spdlog::info("CreateHookPresent= {}", createHookPresent);
+			const MH_STATUS enableHookPresent = MH_EnableHook(pDirect3DSwapChain9->lpVtbl->Present);
+			spdlog::info("EnableHookPresent = {}", enableHookPresent);
+	
+		}
+	}
+
+	void ShareValuesWithSwapChainHook(XInputManager* xInputManager, uint32_t* ff13ButtonPressed, float* ff13AnalogValues) {
+		pXInputManager = xInputManager;
+		pff13ButtonPressed = ff13ButtonPressed;
+		pff13AnalogValues = ff13AnalogValues;
+	}
+}
+
+

--- a/d3d9ex/Settings.h
+++ b/d3d9ex/Settings.h
@@ -60,16 +60,19 @@ SETTING(bool, BoolValue, DisableIngameControllerHotSwapping, FFXIII, true,
 	L"# DisableIngameControllerHotSwapping\n"
 	L"#\n"
 	L"# By default FF13Fix disables the game's continuous controller scanning that causes stuttering (especially if you do not have any controller connected)\n"
-	L"# If you with you can enable it again (by setting the config to 'false', so you can re-connect your controller while playing.\n"
-	L"# Note that EnableControllerVibration is incompatible with the controller hotswapping, \n"
-	L"#  so it is automatically disabled if DisableIngameControllerHotSwapping is set to 'false'"
+	L"# Note that if you are using the FF13Fix XInput implementation, this setting is forced 'true', as hotswapping will work anyway even if the internal game scanning logic is disabled (FF13Fix will use its on hotswapping logic)"
 );
-SETTING(bool, BoolValue, EnableControllerVibration, FFXIII, true, 
+SETTING(bool, BoolValue, Enable, FFXIII_XInput, true,
+	L"# Replace the internal game controller input logic by FF13Fix XInput implementation\n"
+	L"#\n"
+	L"# Controller hotswapping/vibration works without impacting game performance."
+);
+SETTING(bool, BoolValue, EnableControllerVibration, FFXIII_XInput, true,
 	L"# EnableControllerVibration\n"
 	L"#\n"
-	L"# Enables controller vibration on the first connected XInput device."
+	L"# Enables controller vibration."
 );
-SETTING(bool, DoubleValue, VibrationStrengthFactor, FFXIII, 2.0, 
+SETTING(bool, DoubleValue, VibrationStrengthFactor, FFXIII_XInput, 1.0,
 	L"# VibrationStrengthFactor\n"
 	L"#\n"
 	L"# Higher numbers = stronger vibration"

--- a/d3d9ex/XInputManager.cpp
+++ b/d3d9ex/XInputManager.cpp
@@ -1,71 +1,198 @@
 #include "stdafx.h"
 #include "XInputManager.h"
-#include <XInput.h>
 
 XInputManager::XInputManager(uint8_t** base_controller_input_address_ptr, const float vibrationStrengthFactor)
 {
 	this->vibrationStrengthFactor = vibrationStrengthFactor;
 	xinputThread = std::thread(&XInputManager::Run, this, base_controller_input_address_ptr);
+	spdlog::debug("base_controller_input_address_ptr = {}", (void*)base_controller_input_address_ptr);
 }
 
 void XInputManager::Run(uint8_t** base_controller_input_address_ptr)
 {
-	bool hasConnected = false;
-	for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
-		XINPUT_STATE state;
-		ZeroMemory(&state, sizeof(XINPUT_STATE));
+	WaitAndSetVibrationAddress(base_controller_input_address_ptr);
+	ScanForConnectedController();
+}
 
-		const DWORD controllerState = XInputGetState(i, &state);
-		if (controllerState == ERROR_SUCCESS) {
-			controllerId = i;
-			hasConnected = true;
-			break;
+void XInputManager::ScanForConnectedController()
+{
+	spdlog::info("Scanning for connected controllers...");
+
+	while(true){
+		for (uint32_t i = 0; i < XUSER_MAX_COUNT; i++) {
+			XINPUT_STATE state;
+			ZeroMemory(&state, sizeof(XINPUT_STATE));
+
+			const int32_t controllerState = XInputGetState(i, &state);
+			if (controllerState == ERROR_SUCCESS) {
+				spdlog::info("Connected controller {}", i);
+				controllerIdShared.store(i, std::memory_order_release);
+				controllerIdShared.wait(i, std::memory_order_acquire);
+				spdlog::info("Controller {} disconnected. Resuming scanning...", i);
+				break;
+			}
 		}
-	}
-	if (hasConnected) {
-		WaitAndSetVibrationAddress(base_controller_input_address_ptr);
-		VibrationLoop();
+		std::this_thread::sleep_for(std::chrono::seconds(2));
 	}
 }
 
 void XInputManager::WaitAndSetVibrationAddress(uint8_t** base_controller_input_address_ptr)
 {
 	do {
-		std::this_thread::sleep_for(std::chrono::milliseconds(4));
+		std::this_thread::sleep_for(std::chrono::milliseconds(8));
 		if (base_controller_input_address_ptr && *base_controller_input_address_ptr) {
-			vibration_address_low_frequency = (float*)(*base_controller_input_address_ptr + 0x40 + 0x60 - 0x4);
-			vibration_address_high_frequency = vibration_address_low_frequency + 1;
+			vibration_address_high_frequency = (float*)(*base_controller_input_address_ptr + 0x40 + 0x5C);
+			vibration_address_low_frequency = (float*)(*base_controller_input_address_ptr + 0x40 + 0x60);
 		}
 	} while (vibration_address_low_frequency == NULL);
 }
 
-void XInputManager::VibrationLoop()
+void XInputManager::SendVibrationToController()
 {
-	const WORD maxVibrationStrength = 65535;
-	bool wasVibrating = false;
-	SetControllerVibration(0, 0);
-	while (true) {
-		const float vibrationStrengthLowFrequency = *vibration_address_low_frequency;
-		const float vibrationStrengthHighFrequency = *vibration_address_high_frequency;
-		if (vibrationStrengthLowFrequency > 0.01f || vibrationStrengthHighFrequency > 0.01f) {
-			const WORD leftMotorVibration = (WORD) (std::min(vibrationStrengthFactor * vibrationStrengthLowFrequency, 1.0f) * maxVibrationStrength);
-			const WORD rightMotorVibration = (WORD) (std::min(vibrationStrengthFactor * vibrationStrengthHighFrequency, 1.0f) * maxVibrationStrength);
-			SetControllerVibration(leftMotorVibration, rightMotorVibration);
-			wasVibrating = true;
-		}
-		else if (wasVibrating) {
-			SetControllerVibration(0, 0);
-			wasVibrating = false;
-		}
-		std::this_thread::sleep_for(std::chrono::milliseconds(4));
+	if (vibration_address_low_frequency == NULL || vibrationStrengthFactor < 0.0001f || controllerIdMainThread < 0) {
+		return;
 	}
+	const WORD maxVibrationStrength = 65535;
+	const float vibrationStrengthLowFrequency = *vibration_address_low_frequency;
+	const float vibrationStrengthHighFrequency = *vibration_address_high_frequency;
+	const WORD leftMotorVibration = (WORD)(std::min(vibrationStrengthFactor * vibrationStrengthLowFrequency, 1.0f) * maxVibrationStrength);
+	const WORD rightMotorVibration = (WORD)(std::min(vibrationStrengthFactor * vibrationStrengthHighFrequency, 1.0f) * maxVibrationStrength);
+	SetControllerVibration(leftMotorVibration, rightMotorVibration);
 }
 
 void XInputManager::SetControllerVibration(const WORD& leftMotorVibration, const WORD& rightMotorVibration)
 {
-	XINPUT_VIBRATION vibration;
-	ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
-	vibration.wLeftMotorSpeed = leftMotorVibration;
-	vibration.wRightMotorSpeed = rightMotorVibration;
-	XInputSetState(controllerId, &vibration);
+	int32_t controllerToVibrate = controllerIdMainThread;
+
+	if (controllerToVibrate >= 0) {
+		LogValues();
+		XINPUT_VIBRATION vibration;
+		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
+		vibration.wLeftMotorSpeed = leftMotorVibration;
+		vibration.wRightMotorSpeed = rightMotorVibration;
+		XInputSetState(controllerIdMainThread, &vibration);
+	}
+}
+
+
+void XInputManager::ReadValues(uint32_t* buttonBuffer, float* ff13AnalogValues) {
+	if (controllerIdMainThread == -1) {
+		controllerIdMainThread = controllerIdShared.load(std::memory_order_acquire);
+	}
+	if (controllerIdMainThread == -1) {
+		return;
+	}
+	XINPUT_STATE xInputState;
+	ZeroMemory(&xInputState, sizeof(XINPUT_STATE));
+	DWORD getStateStatus = XInputGetState(controllerIdMainThread, &xInputState);
+	if (getStateStatus == ERROR_SUCCESS) {
+		uint16_t analogValueLXIfAboveDeadZone = ZeroAnalogIfBelowDeadZone(xInputState.Gamepad.sThumbLX, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE);
+		uint16_t analogValueLYIfAboveDeadZone = ZeroAnalogIfBelowDeadZone(xInputState.Gamepad.sThumbLY, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE);
+
+		uint16_t analogValueRXIfAboveDeadZone = ZeroAnalogIfBelowDeadZone(xInputState.Gamepad.sThumbRX, XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
+		uint16_t analogValueRYIfAboveDeadZone = ZeroAnalogIfBelowDeadZone(xInputState.Gamepad.sThumbRY, XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
+
+		float leftAnalogX = NormalizeXinputAnalogStick(analogValueLXIfAboveDeadZone);
+		float leftAnalogY = NormalizeXinputAnalogStick(analogValueLYIfAboveDeadZone);
+
+		float rightAnalogX = NormalizeXinputAnalogStick(analogValueRXIfAboveDeadZone);
+		float rightAnalogY = NormalizeXinputAnalogStick(analogValueRYIfAboveDeadZone);
+
+		uint32_t buttonMask = GetFF13ButtonMask(&xInputState);
+
+		*buttonBuffer = buttonMask;
+		// ff13AnalogValues contains the analog stick values. the game accesses the positions 2, 3, 6 and 7 too, but they always seem 0 and unused...
+		ff13AnalogValues[0] = leftAnalogX;
+		ff13AnalogValues[1] = leftAnalogY;
+		
+		ff13AnalogValues[4] = rightAnalogX;
+		ff13AnalogValues[5] = rightAnalogY;
+	}
+	else if (getStateStatus == ERROR_DEVICE_NOT_CONNECTED) {
+		controllerIdMainThread = -1;
+		controllerIdShared.store(-1, std::memory_order_release);
+		controllerIdShared.notify_all();
+	}
+}
+
+uint32_t XInputManager::GetFF13ButtonMask(const XINPUT_STATE* xInputState)
+{
+	uint32_t ff13ButtonMask = 0;
+
+	WORD pressedButtons = xInputState->Gamepad.wButtons;
+
+	if (pressedButtons & XINPUT_GAMEPAD_DPAD_UP) {
+		ff13ButtonMask |= FF13_GAMEPAD_DPAD_UP;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_DPAD_DOWN) {
+		ff13ButtonMask |= FF13_GAMEPAD_DPAD_DOWN;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_DPAD_LEFT) {
+		ff13ButtonMask |= FF13_GAMEPAD_DPAD_LEFT;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_DPAD_RIGHT) {
+		ff13ButtonMask |= FF13_GAMEPAD_DPAD_RIGHT;
+	}
+
+	if (pressedButtons & XINPUT_GAMEPAD_Y) {
+		ff13ButtonMask |= FF13_GAMEPAD_TRIANGLE;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_A) {
+		ff13ButtonMask |= FF13_GAMEPAD_CROSS;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_X) {
+		ff13ButtonMask |= FF13_GAMEPAD_SQUARE;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_B) {
+		ff13ButtonMask |= FF13_GAMEPAD_CIRCLE;
+	}
+
+	if (pressedButtons & XINPUT_GAMEPAD_LEFT_SHOULDER) {
+		ff13ButtonMask |= FF13_GAMEPAD_L1;
+	}
+	if (xInputState->Gamepad.bLeftTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD) {
+		ff13ButtonMask |= FF13_GAMEPAD_L2;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_LEFT_THUMB) {
+		ff13ButtonMask |= FF13_GAMEPAD_L3;
+	}
+
+
+	if (pressedButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER) {
+		ff13ButtonMask |= FF13_GAMEPAD_R1;
+	}
+	if (xInputState->Gamepad.bRightTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD) {
+		ff13ButtonMask |= FF13_GAMEPAD_R2;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_RIGHT_THUMB) {
+		ff13ButtonMask |= FF13_GAMEPAD_R3;
+	}
+
+	if (pressedButtons & XINPUT_GAMEPAD_BACK) {
+		ff13ButtonMask |= FF13_GAMEPAD_SELECT;
+	}
+	if (pressedButtons & XINPUT_GAMEPAD_START) {
+		ff13ButtonMask |= FF13_GAMEPAD_START;
+	}
+
+	return ff13ButtonMask;
+}
+
+float XInputManager::NormalizeXinputAnalogStick(const int16_t value) {
+	return  ((const int)value + 32768) / 32768.0f - 1.0f;
+}
+
+void XInputManager::LogValues()
+{
+	if (vibration_address_low_frequency == NULL) {
+		return;
+	}
+
+	const float vibrationStrengthLowFrequency = *vibration_address_low_frequency;
+	const float vibrationStrengthHighFrequency = *vibration_address_high_frequency;
+	spdlog::info("LF({}) = {} HF({}) = {}", (void*)vibration_address_low_frequency, vibrationStrengthLowFrequency, (void*)vibration_address_high_frequency, vibrationStrengthHighFrequency);
+}
+
+int16_t XInputManager::ZeroAnalogIfBelowDeadZone(const int16_t analogValue, const int16_t deadZoneValue) {
+	return abs(analogValue) > deadZoneValue ? analogValue : 0;
 }

--- a/d3d9ex/XInputManager.cpp
+++ b/d3d9ex/XInputManager.cpp
@@ -108,6 +108,11 @@ void XInputManager::ReadValues(uint32_t* buttonBuffer, float* ff13AnalogValues) 
 		ff13AnalogValues[5] = rightAnalogY;
 	}
 	else if (getStateStatus == ERROR_DEVICE_NOT_CONNECTED) {
+		*buttonBuffer = 0;
+		ff13AnalogValues[0] = 0.0f;
+		ff13AnalogValues[1] = 0.0f;
+		ff13AnalogValues[4] = 0.0f;
+		ff13AnalogValues[5] = 0.0f;
 		controllerIdMainThread = -1;
 		controllerIdShared.store(-1, std::memory_order_release);
 		controllerIdShared.notify_all();

--- a/d3d9ex/XInputManager.cpp
+++ b/d3d9ex/XInputManager.cpp
@@ -65,7 +65,6 @@ void XInputManager::SetControllerVibration(const WORD& leftMotorVibration, const
 	int32_t controllerToVibrate = controllerIdMainThread;
 
 	if (controllerToVibrate >= 0) {
-		LogValues();
 		XINPUT_VIBRATION vibration;
 		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
 		vibration.wLeftMotorSpeed = leftMotorVibration;

--- a/d3d9ex/XInputManager.h
+++ b/d3d9ex/XInputManager.h
@@ -1,16 +1,47 @@
 #pragma once
+#include <XInput.h>
+
 class XInputManager
 {
+	const uint16_t FF13_GAMEPAD_DPAD_UP = 0x0001;
+	const uint16_t FF13_GAMEPAD_DPAD_DOWN = 0x0002;
+	const uint16_t FF13_GAMEPAD_DPAD_LEFT = 0x0004;
+	const uint16_t FF13_GAMEPAD_DPAD_RIGHT = 0x0008;
+	const uint16_t FF13_GAMEPAD_TRIANGLE = 0x0010;
+	const uint16_t FF13_GAMEPAD_CROSS = 0x0020;
+	const uint16_t FF13_GAMEPAD_SQUARE = 0x0040;
+	const uint16_t FF13_GAMEPAD_CIRCLE = 0x0080;
+	const uint16_t FF13_GAMEPAD_L1 = 0x0100;
+	const uint16_t FF13_GAMEPAD_L2 = 0x0200;
+	const uint16_t FF13_GAMEPAD_L3 = 0x0400;
+	const uint16_t FF13_GAMEPAD_R1 = 0x0800;
+	const uint16_t FF13_GAMEPAD_R2 = 0x1000;
+	const uint16_t FF13_GAMEPAD_R3 = 0x2000;
+	const uint16_t FF13_GAMEPAD_SELECT = 0x4000;
+	const uint16_t FF13_GAMEPAD_START = 0x8000;
+
 	float* vibration_address_high_frequency = NULL;
-	float vibrationStrengthFactor;
 	float* vibration_address_low_frequency = NULL;
-	DWORD controllerId = -1;
+	
+	float vibrationStrengthFactor;
+
+	int32_t controllerIdMainThread = -1;
+	std::atomic<int32_t> controllerIdShared;
 	std::thread xinputThread;
+
 public:
 	XInputManager(uint8_t** base_controller_input_address_ptr, const float vibrationStrengthFactor);
+	void ReadValues(uint32_t* buttonBuffer, float* ff13AnalogValues);
+	void SendVibrationToController();
+
+private:
 	void Run(uint8_t** base_controller_input_address_ptr);
+	int16_t ZeroAnalogIfBelowDeadZone(const int16_t analogValue, const int16_t deadZoneValue);
+	float NormalizeXinputAnalogStick(int16_t value);
+	uint32_t GetFF13ButtonMask(const XINPUT_STATE* xInputState);
+	void ScanForConnectedController();
 	void WaitAndSetVibrationAddress(uint8_t** base_controller_input_address_ptr);
-	void VibrationLoop();
 	void SetControllerVibration(const WORD& leftMotorVibration, const WORD& rightMotorVibration);
+	void LogValues();
 };
 

--- a/d3d9ex/d3d9ex.vcxproj
+++ b/d3d9ex/d3d9ex.vcxproj
@@ -208,6 +208,10 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="IDirect3DSwapChain9Hook.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="XInputManager.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/d3d9ex/d3d9ex.vcxproj.filters
+++ b/d3d9ex/d3d9ex.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="VertexFix.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="IDirect3DSwapChain9Hook.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def">


### PR DESCRIPTION
Should hopefully fix the issue where some users would get incorrect controller mapping/spinning camera.

https://steamcommunity.com/app/292120/discussions/0/4312743731808007161/
https://steamcommunity.com/app/292120/discussions/0/613938693134914508/
https://steamcommunity.com/app/292120/discussions/0/3047230236583754130/
https://steamcommunity.com/app/292120/discussions/1/3047231300180681161/
https://steamcommunity.com/app/292120/discussions/0/141136086923284332/

Also allows hotswapping controllers without any slowdown, and fixes two issues with vibration:

1. High/Low frequency vibration variables were swapped (probably the real cause of https://github.com/rebtd7/FF13Fix/issues/24, the motor used the most by the game is the strongest one and we were incorrectly using the weaker one)

2. Vibration was not working after hotswapping

Vibration also now runs in the main thread (should be more accurate)