### PR TITLE
Use dinput8.dll to prevent crashes with new Steam update

### DIFF
--- a/d3d9ex/IDirect3D9.cpp
+++ b/d3d9ex/IDirect3D9.cpp
@@ -22,7 +22,10 @@ HRESULT APIENTRY hkIDirect3D9::QueryInterface(REFIID riid, void** ppvObj) {
 			IDirect3D9Ex* pIDirect3D9Ex = nullptr;
 			HRESULT hr = m_pWrapped->QueryInterface(riid, reinterpret_cast<void**>(&pIDirect3D9Ex));
 			if (FAILED(hr))
+			{
+				spdlog::trace("Error creating IDirect3D9Ex: {:#X}", (unsigned long)hr);
 				return hr;
+			}
 
 			// release one reference from old one and take new IDirect3DDevice9Ex pointer 
 			m_pWrapped->Release();

--- a/d3d9ex/IDirect3D9.h
+++ b/d3d9ex/IDirect3D9.h
@@ -35,13 +35,14 @@ public:
 	hkIDirect3D9(IDirect3D9Ex* pIDirect3D9)
 		: m_pWrapped(pIDirect3D9)
 	{
+		AddRef();
 	}
 
 	virtual ~hkIDirect3D9() { }
 
 private:
 	IDirect3D9Ex* m_pWrapped;
-	ULONG m_ref = 1;
+	ULONG m_ref;
 	bool m_is_ex = false;
 
 	template <typename T, bool ex>

--- a/d3d9ex/IDirect3DDevice9.cpp
+++ b/d3d9ex/IDirect3DDevice9.cpp
@@ -14,7 +14,8 @@ HRESULT APIENTRY hkIDirect3DDevice9::QueryInterface(REFIID riid, void** ppvObj) 
 	if (riid == __uuidof(this) ||
 		riid == __uuidof(IUnknown) ||
 		riid == __uuidof(IDirect3DDevice9) ||
-		riid == __uuidof(IDirect3DDevice9Ex))
+		riid == __uuidof(IDirect3DDevice9Ex) 
+		)
 	{
 		if (!m_is_ex && riid == __uuidof(IDirect3DDevice9Ex))
 		{
@@ -23,7 +24,10 @@ HRESULT APIENTRY hkIDirect3DDevice9::QueryInterface(REFIID riid, void** ppvObj) 
 			IDirect3DDevice9Ex* pIDirect3DDevice9Ex = nullptr;
 			HRESULT hr = m_pWrapped->QueryInterface(riid, reinterpret_cast<void**>(&pIDirect3DDevice9Ex));
 			if (FAILED(hr))
+			{
+				spdlog::trace("Error creating IDirect3DDevice9Ex: {:#X}", (unsigned long)hr);
 				return hr;
+			}
 
 			// release one reference from old one and take new IDirect3DDevice9Ex pointer 
 			m_pWrapped->Release();

--- a/d3d9ex/IDirect3DDevice9.h
+++ b/d3d9ex/IDirect3DDevice9.h
@@ -147,13 +147,14 @@ public:
 	hkIDirect3DDevice9(IDirect3DDevice9Ex* pIDirect3DDevice9, bool is_ex)
 		: m_pWrapped(pIDirect3DDevice9), m_is_ex(is_ex)
 	{
+		AddRef();
 	}
 
 	virtual ~hkIDirect3DDevice9() { }
 
 private:
 	IDirect3DDevice9Ex* m_pWrapped;
-	ULONG m_ref = 1;
+	ULONG m_ref;
 	bool m_is_ex = false;
 };
 

--- a/d3d9ex/Wrapper.h
+++ b/d3d9ex/Wrapper.h
@@ -78,6 +78,9 @@ public:
 	void (WINAPI* D3DPERF_SetOptions)(DWORD dwOptions);
 	void (WINAPI* D3DPERF_SetRegion)(D3DCOLOR col, LPCWSTR wszName);
 
+	HRESULT(WINAPI* DebugSetLevel)(DWORD level);
+	void (WINAPI* DebugSetMute)(void);
+
 	bool IsDXVK() { return m_isdxvk; }
 
 	D3D9DLL()
@@ -102,6 +105,9 @@ public:
 		StoreAddress(&D3DPERF_SetMarker, "D3DPERF_SetMarker");
 		StoreAddress(&D3DPERF_SetOptions, "D3DPERF_SetOptions");
 		StoreAddress(&D3DPERF_SetRegion, "D3DPERF_SetRegion");
+
+		StoreAddress(&DebugSetLevel, "DebugSetLevel");
+		StoreAddress(&DebugSetMute, "DebugSetMute");
 	}
 
 private:
@@ -154,5 +160,37 @@ extern "C"
 	void WINAPI _D3DPERF_SetRegion(D3DCOLOR col, LPCWSTR wszName)
 	{
 		return D3D9DLL::Get().D3DPERF_SetRegion(col, wszName);
+	}
+
+	HRESULT WINAPI _DebugSetLevel(DWORD level)
+	{
+		return D3D9DLL::Get().DebugSetLevel(level);
+	}
+
+	void WINAPI _DebugSetMute()
+	{
+		D3D9DLL::Get().DebugSetMute();
+	}
+}
+
+class DINPUT8DLL : public WrapperBase<DINPUT8DLL>
+{
+public:
+
+	HRESULT(WINAPI* DirectInput8Create)(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID* ppvOut, LPUNKNOWN punkOuter);
+
+	DINPUT8DLL()
+	{
+		WrapperLoad("dinput8.dll");
+
+		StoreAddress(&DirectInput8Create, "DirectInput8Create");
+	}
+};
+
+extern "C"
+{
+	HRESULT WINAPI _DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID* ppvOut, LPUNKNOWN punkOuter)
+	{
+		return DINPUT8DLL::Get().DirectInput8Create(hinst, dwVersion, riidltf, ppvOut, punkOuter);
 	}
 }

--- a/d3d9ex/d3d9ex.vcxproj
+++ b/d3d9ex/d3d9ex.vcxproj
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -44,7 +44,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <InterproceduralOptimization>true</InterproceduralOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -53,7 +53,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <InterproceduralOptimization>true</InterproceduralOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -83,7 +83,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>d3d9</TargetName>
+    <TargetName>dinput8</TargetName>
     <IncludePath>$(SolutionDir)\Common;$(SolutionDir)\Deps\MinHook\include;$(SolutionDir)\Deps\spdlog\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -93,7 +93,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;SPDLOG_DISABLE_DEFAULT_LOGGER;SPDLOG_WCHAR_TO_UTF8_SUPPORT;_DEBUG;_WINDOWS;_USRDLL;D3D9EX_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -134,7 +134,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <CreateHotpatchableImage>true</CreateHotpatchableImage>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/d3d9ex/exports.def
+++ b/d3d9ex/exports.def
@@ -11,4 +11,7 @@ D3DPERF_SetMarker=_D3DPERF_SetMarker @24
 D3DPERF_SetOptions=_D3DPERF_SetOptions @25
 D3DPERF_SetRegion=_D3DPERF_SetRegion @26
 
+DebugSetLevel=_DebugSetLevel @27
+DebugSetMute=_DebugSetMute @28
 
+DirectInput8Create=_DirectInput8Create


### PR DESCRIPTION
Hello @rebtd7 

New Steam update seems to cause crashes when using d3d9.dll, i need to debug this deeper but workaround for now is to just use dinput8.dll as it seems to work fine and we can use both same time and just rename dll file if needed as my multiwrapper idea i have used in OneTweakNG solves this.
Yes - we will loose dxvk and reshade when using as dinput8.dll but... it works, for now.

PS: it seems now Steam GameOverlayRenderer.dll is loaded even if overlay is disabled in game properties...